### PR TITLE
Set app environment variables for running 3rd party apps as extensions

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -508,6 +508,20 @@ BOOL WINAPI ConsoleHandlerRoutine(DWORD dwCtrlType) {
 	return FALSE;
 }
 
+static void SetShortcutEnvironments(WCHAR *wCD) {
+	WCHAR wchPath[32767] = L"", *p;
+	int len = lstrlen(wCD);
+
+	p = wchPath + len + 1;
+	GetEnvironmentVariable(L"Path", p, 32767 - 1 - len);
+	if (!StrHasPrefixCaseEx(p, wCD, len) && p[len] != L';') {
+		lstrcpy(wchPath, wCD);
+		wchPath[len] = L';';
+		SetEnvironmentVariable(L"Path", wchPath);
+	}
+	SetEnvironmentVariable(L"N2Root", wCD);
+}
+
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nShowCmd) {
 	UNREFERENCED_PARAMETER(hPrevInstance);
 	UNREFERENCED_PARAMETER(lpCmdLine);
@@ -555,6 +569,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 	GetModuleFileName(NULL, wchWorkingDirectory, COUNTOF(wchWorkingDirectory));
 	PathRemoveFileSpec(wchWorkingDirectory);
 	SetCurrentDirectory(wchWorkingDirectory);
+
+	SetShortcutEnvironments(wchWorkingDirectory);
 
 	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
 


### PR DESCRIPTION
Kind of solution for https://github.com/zufuliu/notepad2/issues/259.

For `grepWin` using a launcher:
1. Prepare the grepWin. Locate it in `D:\grepWin\grepWin_portable.exe` for example.
2. Create a script `gw.bat`:
   ```bat
   @start D:\grepWin\grepWin_portable.exe /content /searchpath:"%cd%"
   ```
3. Config the command line of grepWin editor setting to `notepad2 /g %line% %path%`.
4. `Ctrl + R` --> `gw`, search or replace.
5. Double click the search result will locate the line in notepad2.

For `ripgrep`:
1. Locate `rg.exe` in the same directory as `notepad2`.
2. `Ctrl + R` --> `cmd` --> `rg`.


`N2Root` is in case of there is the same name files in the directory of the opened file and notepad2, it can be used as a short and unique prefix.
