### PR TITLE
[CSV] Fix row count for group folding

### DIFF
--- a/scintilla/lexers/LexCSV.cxx
+++ b/scintilla/lexers/LexCSV.cxx
@@ -47,7 +47,7 @@ void ColouriseCSVDoc(Sci_PositionU startPos, Sci_Position lengthDoc, int initSty
 	initStyle = SCE_CSV_COLUMN_0;
 	Sci_Line lineCurrent = styler.GetLine(startPos);
 	if (lineCurrent > 0) {
-		rows = static_cast<int>(lineCurrent % CsvRowGroup);
+		rows = static_cast<int>((lineCurrent - 1) % CsvRowGroup);
 		const int lineState = styler.GetLineState(lineCurrent - 1);
 		if (lineState) {
 			quoted = true;


### PR DESCRIPTION
The 1st group had 1 row less.
![csv-folding](https://github.com/user-attachments/assets/a52216cd-a812-47cb-935f-7a49b9419a7b)
