### PR TITLE
add NSIS installer build steps in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
     - uses: actions/upload-artifact@v5
       with:
-          name: Notepad4_MSVC_Installers_${{ matrix.platform }}
+          name: Notepad4_MSVC_Installer_${{ matrix.platform }}
           path: 'build/Notepad4-*.exe'
 
     - uses: actions/upload-artifact@v5

--- a/build/Notepad4.nsi
+++ b/build/Notepad4.nsi
@@ -72,6 +72,7 @@ Section "Notepad4 Main Program" SEC_MAIN
   WriteRegStr HKCU "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\Notepad4.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayName" "${PRODUCT_NAME}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninstall.exe"
+  WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
   WriteUninstaller "$INSTDIR\uninstall.exe"
 SectionEnd
 


### PR DESCRIPTION
Changes:
 - Added `build/Notepad4.nsi` to pack msvc builds into installers.
 - Added steps in `main.yml` to build and upload installer artifacts ( only MSVC )
 - Changed steps in `main.yml` to matrix configurations.
