### PR TITLE
Fix strcat() buffer over-read in ConvertNumRadix

### DIFF
--- a/src/Edit.cpp
+++ b/src/Edit.cpp
@@ -2364,7 +2364,7 @@ static int ConvertNumRadix(char *tch, uint64_t num, int radix) noexcept {
 
 	case 8: {
 		char buf[2 + 22 + 1] = "";
-		int index = 2 + 22;
+		int index = 2 + 22 - 1;
 		int length = 0;
 		while (num) {
 			const int bit = static_cast<int>(num & 7);
@@ -2386,7 +2386,7 @@ static int ConvertNumRadix(char *tch, uint64_t num, int radix) noexcept {
 
 	case 2: {
 		char buf[2 + 64 + 8 + 1] = "";
-		int index = 2 + 64 + 8;
+		int index = 2 + 64 + 8 - 1;
 		int length = 0;
 		int bit_count = 0;
 		while (num) {


### PR DESCRIPTION
Keep the last byte of the local buffer reserved as the null terminator so strcat() never reads beyond array bounds.

> This bug can cause garbled output after conversion (reproduced on Win11, but not on Win10), as shown in the screenshot below.

<img width="2406" height="1262" alt="image" src="https://github.com/user-attachments/assets/a7cb0919-8ee7-4606-aa2e-9d66367e5e40" />

