### PR TITLE
Improve command line option `/g`

### DIFF
--- a/src/Notepad4.cpp
+++ b/src/Notepad4.cpp
@@ -391,6 +391,7 @@ static bool	flagPasteBoard			= false;
 static int	flagSetEncoding			= 0;
 static int	flagSetEOLMode			= 0;
 static bool	flagJumpTo				= false;
+static bool	flagJumpToLinePos		= false;
 static MatchTextFlag flagMatchText	= MatchTextFlag_None;
 static TripleBoolean flagChangeNotify = TripleBoolean_NotSet;
 static bool	flagLexerSpecified		= false;
@@ -892,6 +893,10 @@ void InitInstance(HINSTANCE hInstance, int nCmdShow) {
 
 		if (bOpened) {
 			if (flagJumpTo) { // Jump to position
+				if (flagJumpToLinePos) {
+					iInitialColumn = SciCall_GetColumn(SciCall_PositionFromLine(iInitialLine - 1) + iInitialColumn);
+					flagJumpToLinePos = false;
+				}
 				EditJumpTo(iInitialLine, iInitialColumn);
 			}
 			if (flagChangeNotify != TripleBoolean_NotSet) {
@@ -1339,7 +1344,8 @@ LRESULT CALLBACK MainWndProc(HWND hwnd, UINT umsg, WPARAM wParam, LPARAM lParam)
 
 			if (params->flagJumpTo) {
 				const Sci_Line iLine = params->iInitialLine ? params->iInitialLine : 1;
-				EditJumpTo(iLine, params->iInitialColumn);
+				const Sci_Position iColumn = params->flagJumpToLinePos ? params->iInitialColumn :  SciCall_GetColumn(SciCall_PositionFromLine(iLine - 1) + params->iInitialColumn);
+				EditJumpTo(iLine, iColumn);
 			}
 			if (bOpened && params->flagMatchText != MatchTextFlag_None) {
 				HandleMatchText(params->flagMatchText, lpsz, params->flagJumpTo);
@@ -5717,6 +5723,7 @@ CommandParseState ParseCommandLineOption(LPWSTR lp1, LPWSTR lp2) noexcept {
 #endif
 				if (itok != 0) {
 					flagJumpTo = true;
+					flagJumpToLinePos = true;
 					state = CommandParseState_Consumed;
 					iInitialLine = cord[0];
 					iInitialColumn = cord[1];
@@ -7348,6 +7355,7 @@ static void ActivatePrevWindow(HWND hwnd, LPCWSTR lpszFile) noexcept {
 	params->flagQuietCreate = flagQuietCreate;
 	params->flagTitleExcerpt = false;
 	params->flagJumpTo = flagJumpTo;
+	params->flagJumpToLinePos = flagJumpToLinePos;
 	params->flagChangeNotify = flagChangeNotify;
 
 	LPWSTR lpsz = &params->wchData;

--- a/src/Notepad4.h
+++ b/src/Notepad4.h
@@ -64,6 +64,7 @@ struct NP2PARAMS {
 	bool	flagQuietCreate;
 	bool	flagTitleExcerpt;
 	bool	flagJumpTo;
+	bool	flagJumpToLinePos;
 	TripleBoolean	flagChangeNotify;
 	int		iInitialLexer;
 	Sci_Line		iInitialLine;

--- a/src/Notepad4.rc
+++ b/src/Notepad4.rc
@@ -1859,7 +1859,7 @@ file\tMust be the last argument, no quoted spaces by default.\n\
 …\t/utf8, /utf8sig, /utf8bom, /utf16, /utf16le, /utf16be).\n\
 …\tLine ending mode (/crlf, /lf, /cr).\n\
 /e encoding\tFile source encoding.\n\
-/g line[,column]\tJump to specified position (/g -1 end of file).\n\
+/g line[,character]\tJump to specified position (/g -1 end of file).\n\
 /m text\tMatch specified text (/m- last, /mr regex, /mb backslash).\n\
 /l[o]\tAuto-reload modified files.\n\
 /q\tForce creation of new files without prompt.\n\


### PR DESCRIPTION
Ensure it goes to the correct location, if there are Tabs. More practical. This option is more likely designed for being used by other apps, which won't know the actual Tab width.

虽然 column 是习惯性叫法，但是对于有 Tab 的情况，用本程序打开文件并定位到相应的位置前，外部很难知道“正确的”列号。Tab 的宽度在不同场景下是可变的。Char 序号更实用。